### PR TITLE
Remove mistaken use of "proprietary"

### DIFF
--- a/explore-cardano/how-are-new-blocks-produced.md
+++ b/explore-cardano/how-are-new-blocks-produced.md
@@ -6,7 +6,7 @@ Submitted valid transactions might be included in any new block. A block is cryp
 
 ### Slots and Epochs
 
-The Cardano blockchain uses the proprietary Ouroboros Praos protocol to facilitate consensus on the chain.
+The Cardano blockchain uses the Ouroboros Praos protocol to facilitate consensus on the chain.
 
 Ouroboros Praos divides time into epochs. Each Cardano epoch consists of a number of slots, where each slot lasts for one second. A Cardano epoch currently includes 432,000 slots (5 days). In any slot, zero or more block-producing nodes might be nominated to be the slot leader. On average, one node is expected to be nominated every 20 seconds, for a total of 21,600 nominations per epoch. If randomly elected slot leaders produce blocks, one of them will be added to the chain. Other candidate blocks will be discarded.
 


### PR DESCRIPTION
Ouroboros is not "proprietary". IOHK has no patents on this, the code is all MIT and the research paper is free to read by anyone