### PR TITLE
Use main sphinx_rtd_theme instead of fork

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -1,8 +1,8 @@
 Sphinx==3.1.1
 sphinx-intl==2.0.1
+sphinx_rtd_theme==0.5.2
 transifex-client==0.13.10
 testresources==2.0.1
--e git+https://github.com/input-output-hk/sphinx_rtd_theme.git#egg=sphinx_rtd_theme
 recommonmark==0.6
 ## The following requirements were added by pip freeze:
 alabaster==0.7.12

--- a/conf.py
+++ b/conf.py
@@ -51,6 +51,9 @@ extensions = [
 templates_path = ['.sphinx/_templates']
 html_static_path = ['.sphinx/_static']
 
+# hide 'Built with Sphinx using a theme provided by Read the Docs'
+html_show_sphinx = False
+
 source_suffix = {
     '.rst': 'restructuredtext',
     '.md': 'markdown',


### PR DESCRIPTION
There was no need to use a fork here simply set `html_show_sphinx = 
False`, this removes the need for 
https://github.com/input-output-hk/sphinx_rtd_theme (forked and modified 
with 
https://github.com/input-output-hk/sphinx_rtd_theme/commit/12c5bccf1cc1f5794f482df79d6857e0ec52803f) 
and removes the extra maintence cost.

This change also bumbs the theme version to 0.5.2 which includes some 
fixes to fix compatibility with newer sphinx versions.

FWIW I am the maintainer of sphinx_rtd_theme