### PR TITLE
Fix hard coded copyright year

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -7,6 +7,7 @@ import recommonmark
 
 from recommonmark.transform import AutoStructify
 from os.path import abspath, join, dirname
+from datetime import datetime
 
 sys.path.insert(0, abspath(join(dirname(__file__))))
 
@@ -22,7 +23,8 @@ if rtd_version not in ["stable", "latest"]:
 # -- Project information -----------------------------------------------------
 
 project = 'Cardano Documentation'
-copyright = '2020, IOHK'
+current_year = datetime.now().year
+copyright = f'{current_year}, IOHK'
 author = 'IOHK'
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
#### Addressed Issue

Addresses #71.

#### Made changes

[conf.py](https://github.com/cardano-foundation/docs-cardano-org/blob/main/conf.py): I interpolated the string `copyright` with the current year, retrieved from `datetime.datetime.now()`. This way when the documentation is rebuilt from the source, always the active year will be displayed next to the copyright symbol in the footer of the page.